### PR TITLE
Resolve PHP 7.1.1 Fatal Error

### DIFF
--- a/inc/css.php
+++ b/inc/css.php
@@ -22,6 +22,7 @@ class SiteOrigin_Panels_Lite_Css_Builder {
 	 * @param int $resolution The pixel resolution that this applies to
 	 */
 	function add_css($selector, $attributes, $resolution = 1920) {
+		$attribute_string = array();
 		foreach( $attributes as $k => $v ) {
 			$attribute_string[] = $k.':'.$v;
 		}

--- a/inc/css.php
+++ b/inc/css.php
@@ -22,7 +22,6 @@ class SiteOrigin_Panels_Lite_Css_Builder {
 	 * @param int $resolution The pixel resolution that this applies to
 	 */
 	function add_css($selector, $attributes, $resolution = 1920) {
-		$attribute_string = '';
 		foreach( $attributes as $k => $v ) {
 			$attribute_string[] = $k.':'.$v;
 		}


### PR DESCRIPTION
[Reported here](https://siteorigin.com/?post_type=thread&p=43626).

This PR will prevent this error on PHP 7.1.1:
<b>Fatal error</b>:  Uncaught Error: [] operator not supported for strings in /var/www/content/themes/vantage/inc/panels-lite/inc/css.php:27

Basically, there's little reason to specify $attribute_string so I removed it.